### PR TITLE
Fix bug running simulations after an error is raised.

### DIFF
--- a/src/main/java/org/geppetto/simulation/manager/ExperimentRunManager.java
+++ b/src/main/java/org/geppetto/simulation/manager/ExperimentRunManager.java
@@ -314,7 +314,7 @@ class ExperimentRunChecker extends TimerTask
 		}
 		catch(GeppettoExecutionException e)
 		{
-			throw new RuntimeException(e);
+			logger.error(e);
 		}
 	}
 }


### PR DESCRIPTION
This one liner PR solves an error we were having at OSB. When there was an error in a external simulation any other simulation would stay forever 'In Queue'. The problem is that we were throwing an exception in the timer task in charge of retrieving the simulations from the queue and start the execution. Therefore, this timer task was never called again.