### PR TITLE
fix "plot all recorded variables" issue

### DIFF
--- a/src/main/java/org/geppetto/simulation/manager/GeppettoManager.java
+++ b/src/main/java/org/geppetto/simulation/manager/GeppettoManager.java
@@ -368,6 +368,14 @@ public class GeppettoManager implements IGeppettoManager
 					// since it's id based
 					DataManagerHelper.getDataManager().addGeppettoProject(project, getUser());
 
+                                        // update the ids of ExperimentState objects
+                                        RuntimeProject runtimeProject = getRuntimeProject(project);
+                                        for (IExperiment experiment : project.getExperiments()) {
+                                            ExperimentState experimentState = runtimeProject.getRuntimeExperiment(experiment).getExperimentState();
+                                            experimentState.setExperimentId(experiment.getId());
+                                            experimentState.setProjectId(project.getId());
+                                        }
+
 					URL url = URLReader.getURL(project.getGeppettoModel().getUrl(), project.getBaseURL());
 					Path localGeppettoModelFile = Paths.get(URLReader.createLocalCopy(scope, project.getId(), url, true).toURI());
 

--- a/src/main/java/org/geppetto/simulation/manager/RuntimeExperiment.java
+++ b/src/main/java/org/geppetto/simulation/manager/RuntimeExperiment.java
@@ -306,6 +306,8 @@ public class RuntimeExperiment
 		ExperimentState experimentStateTransfer = GeppettoFactory.eINSTANCE.createExperimentState();
 		experimentStateTransfer.setExperimentId(experiment.getId());
 		experimentStateTransfer.setProjectId(experiment.getParentProject().getId());
+                experimentState.setExperimentId(experiment.getId());
+                experimentState.setProjectId(experiment.getParentProject().getId());
 
 		for(ISimulationResult result : experiment.getSimulationResults())
 		{

--- a/src/main/java/org/geppetto/simulation/manager/RuntimeExperiment.java
+++ b/src/main/java/org/geppetto/simulation/manager/RuntimeExperiment.java
@@ -275,8 +275,6 @@ public class RuntimeExperiment
 		ExperimentState experimentStateTransfer = GeppettoFactory.eINSTANCE.createExperimentState();
 		experimentStateTransfer.setExperimentId(experiment.getId());
 		experimentStateTransfer.setProjectId(experiment.getParentProject().getId());
-                experimentState.setExperimentId(experiment.getId());
-                experimentState.setProjectId(experiment.getParentProject().getId());
 
 		for(ISimulationResult result : experiment.getSimulationResults())
 		{


### PR DESCRIPTION
fixes "plot all recorded variables" issue (https://github.com/OpenSourceBrain/geppetto-osb/issues/37) (cause = uninitialized experiment and project IDs returned, so frontend treats it as if variables for an external project were request)

to replicate issue:

1. http://0.0.0.0:3000/projects/mainenetalpyramidalcell/models?explorer=https%253A%252F%252Fraw.githubusercontent.com%252FOpenSourceBrain%252FMainenEtAl_PyramidalCell%252Fmaster%252FneuroConstruct%252FgeneratedNeuroML2%252FOneComp.net.nml

2. persist

3. run -> record all at soma

4. plot all recorded variables

5. spinner activated/stops spinning but plot remains blank