### PR TITLE
disallow set experiment view if no write permission

### DIFF
--- a/src/main/java/org/geppetto/simulation/manager/GeppettoManager.java
+++ b/src/main/java/org/geppetto/simulation/manager/GeppettoManager.java
@@ -645,6 +645,12 @@ public class GeppettoManager implements IGeppettoManager
 	@Override
 	public void setExperimentView(String view, IExperiment experiment, IGeppettoProject project) throws GeppettoExecutionException, GeppettoAccessException
 	{
+
+		if(!user.getUserGroup().getPrivileges().contains(UserPrivileges.WRITE_PROJECT))
+		{
+			throw new GeppettoAccessException("Insufficient access rights to set experiment view.");
+		}
+
 		IView v = null;
 
 		if(experiment != null)


### PR DESCRIPTION
this fixes issue with OSB sample projects having their experiment state written (since they are persisted, see comodl because osb.org has a temporary fix in place; for example every time you open HH there are more popups because the script runs, and the ones from before have been saved)